### PR TITLE
[local] Migrate gitlab template to v3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-delivery.yml
+include: https://gitlab-templates.ddbuild.io/compute-delivery/v3/compute-delivery.yml
 
 test:
   stage: verify


### PR DESCRIPTION
Migrate the GitLab CI template include from compute-delivery/v2 to compute-delivery/v3.